### PR TITLE
Remove hard coded project version

### DIFF
--- a/project.ini
+++ b/project.ini
@@ -1,5 +1,5 @@
 [project]
-version = 1.2.1
+version = 1.2.2
 name = nfs
 label = NFS
 

--- a/templates/nfs.txt
+++ b/templates/nfs.txt
@@ -60,7 +60,7 @@ Category = Filesystems
        type = nfs
        export_path = /mnt/exports/data
       
-       [[[cluster-init cyclecloud/nfs:default:1.2.1]]]
+       [[[cluster-init cyclecloud/nfs:default]]]
 
        [[[network-interface eth0]]]
        AssociatePublicIpAddress = $UsePublicNetwork


### PR DESCRIPTION
Cluster-init projects in our built-in cluster templates should use "latest"